### PR TITLE
 added top genres to listening data

### DIFF
--- a/api/utils/spotifyData.js
+++ b/api/utils/spotifyData.js
@@ -107,6 +107,7 @@ const getAvgFeats = (user, db, songs, next) => {
   }
   //console.log(albums)
   genreArtists = genreArtists.filter((el,i,a) => i === a.indexOf(el));
+  genreArtists = genreArtists.slice(0,50)
   spotifyAccessToken = user['spotifyAuthTokens']['access'];
   axios.get(`https://api.spotify.com/v1/audio-features?ids=${idQueries}`,
   {headers: { Authorization: `Bearer ${spotifyAccessToken}`}})

--- a/api/utils/spotifyData.js
+++ b/api/utils/spotifyData.js
@@ -75,6 +75,8 @@ const getAvgFeats = (user, db, songs, next) => {
   "acousticness","instrumentalness","liveness",
   "valence","tempo","duration_ms","time_signature"];
   var idQueries = "";
+  let genreArtists = [];
+  let genres = {};
   for (let song of songs['items']){
     song['album'] = {
       name: song['album']['name'],
@@ -86,6 +88,7 @@ const getAvgFeats = (user, db, songs, next) => {
         name: artist['name'],
         id: artist['id'],
       })
+      genreArtists.push(artist['id']);
     }
     song['artists'] = artists;
     delete song["available_markets"];
@@ -102,6 +105,8 @@ const getAvgFeats = (user, db, songs, next) => {
     data['songs'].push(song);
     data['avgFeatures']['popularity'] += song['popularity'];
   }
+  //console.log(albums)
+  genreArtists = genreArtists.filter((el,i,a) => i === a.indexOf(el));
   spotifyAccessToken = user['spotifyAuthTokens']['access'];
   axios.get(`https://api.spotify.com/v1/audio-features?ids=${idQueries}`,
   {headers: { Authorization: `Bearer ${spotifyAccessToken}`}})
@@ -114,7 +119,29 @@ const getAvgFeats = (user, db, songs, next) => {
     for (let feature of Object.keys(data['avgFeatures'])){
       data['avgFeatures'][feature] /= data['songs'].length;
     }
-    next(null, data);
+    //TO-DO: Query and Save to Cache
+    axios.get(`https://api.spotify.com/v1/artists?ids=${genreArtists.join(',')}`,
+    {headers: { Authorization: `Bearer ${spotifyAccessToken}`}})
+    .then(results => {
+      for (let artist of results['data']['artists']){
+        //console.log(artist)
+        for (let genre of artist['genres']){
+          //console.log(genre)
+          if (genre in genres) genres[genre] += 1;
+          else genres[genre] = 1;
+        }
+      }
+      //console.log(genres);
+      sortableGenres = Object.keys(genres).map(key => { return {genre: key, count: genres[key]} })
+      //console.log(sortableGenres)
+      sortableGenres = sortableGenres.sort((g1, g2) => g2.count - g1.count)
+      data['sortedGenres'] = sortableGenres
+      //console.log(sortableGenres)
+      next(null, data);
+    })
+    .catch(err => {
+      next(err, data);
+    })
   })
   .catch(err => {
     next(err,data);


### PR DESCRIPTION
The Listening Data object of the user now has a sorted list of genres that a user listens to under the key "sortedGenres."

This list is populated by grabbing the info of all the artists that appear in a users top track, grabbing all the genres of those artists, and producing a list that associates
- This is necessary as genres in spotify's api are only associated with artists and not tracks or albums (¯\\_(ツ)__/¯)

listeninData.sortedGenres is an array of objects that contain the keys:
- genre: name of the genre
- count: how many times a genre appears among the user's top artists

![Screen Shot 2019-04-10 at 9 56 05 PM](https://user-images.githubusercontent.com/9355416/55925566-e2a5e880-5bdb-11e9-85f1-6cc6d9abb8b8.png)
