### PR TITLE
Recommendations and Profiles

### DIFF
--- a/client/src/components/Search.js
+++ b/client/src/components/Search.js
@@ -15,7 +15,7 @@ class Search extends Component {
     axios.get(`/search?search=${target.value}`, { headers: {'Authorization' : 'Bearer ' + Cookies.get('cookie')} })
     .then(res => {
       if (res.data.tracks.items) {
-        console.log(res.data.tracks.items)
+        //console.log(res.data.tracks.items)
         this.setState({
           [name]: target.value,
           results: res.data.tracks.items
@@ -65,7 +65,7 @@ class Search extends Component {
         return(<li data-id={i} onClick={(e) => onClick(e, this.state.results)}>{track.name} by {track.artists[0].name} of {track.album.name}</li>)
       })
     }
-    console.log(tracks)
+    //console.log(tracks)
     return(
       <div>
       <Input

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -20,6 +20,27 @@ class Profile extends Component {
   // Object.entries(res.data[0].listeningData.avgFeatures) -> for each loops thru data
   // Object.entries(res.data[0].listeningData.avgFeatures).filter(item=> item[0] !=="duration_ms") -> filter out ms for now
   // Remove .filter(item=> item[0] !=="duration_ms") => .map(item => item[0]) when graph options fixed.
+	componentDidMount(){
+		const { data }  = this.props;
+		if (!(data.listeningData)) this.spotifyData();
+    else {
+      let array = Object.entries(
+        data.listeningData.avgFeatures
+      ).filter(item => item[0] !== "duration_ms");
+      this.setState({
+        features: array,
+        featuresName: array.map(item => item[0]),
+        featuresValue: array.map(item => item[1]),
+        topSongs: Object.entries(data.listeningData.songs).map(
+          item => item[1].name
+        ),
+        loadingDone: true
+      });
+      console.log(this.state.topSongs);
+      console.log(Object.entries(data));
+    }
+	}
+
   spotifyData = () => {
     axios.get("/user/listening-data", {
       headers: { Authorization: "Bearer " + Cookies.get("cookie") }
@@ -60,7 +81,7 @@ class Profile extends Component {
     };
     return <Bar data={data} />;
   };
-  
+
   //maps top 3 songs, change number for more or less songs
   SongList = () => {
     let songs = this.state.topSongs.slice(0,3).map((item =>
@@ -73,7 +94,7 @@ class Profile extends Component {
       </ul>
     )
   }
-	
+
   render() {
     const { data, location } = this.props;
     const { username } = data;

--- a/client/src/pages/ProtectedRoute.js
+++ b/client/src/pages/ProtectedRoute.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Redirect } from 'react-router-dom';
 import Header from '../components/Header';
-import PropTypes from 'prop-types';  
+import PropTypes from 'prop-types';
 import Cookies from 'js-cookie';
 import axios from 'axios';
 

--- a/client/src/pages/Recommendation.Js
+++ b/client/src/pages/Recommendation.Js
@@ -1,16 +1,95 @@
 import React, { Component } from "react";
 import Header from '../components/Header';
+import Search from '../components/Search';
+import Button from "../components/Button";
 import MediaQuery from 'react-responsive';
 import '../styles/Home.css';
+import axios from "axios";
+import Cookies from "js-cookie";
 
 class Recommendation extends Component {
 	constructor(props){
     super(props);
+    this.state = {
+      displayRecs: false,
+      seedTracks: [],
+      seedArtists: [],
+      seedGenres: []
+    }
 	}
-	
+
+  recOnTrackClick = (e, tracks) => {
+    if (e.currentTarget.dataset.id) {
+      let seedTracks = this.state.seedTracks;
+      if (seedTracks.length <=4){
+        seedTracks.push(tracks[e.currentTarget.dataset.id]);
+        this.setState({seedTracks: seedTracks});
+        //console.log(this.state.seedTracks)
+      }
+    }
+  }
+
+  removeFromTracks(e, track){
+    let filteredSeedTracks = this.state.seedTracks.filter((seedTrack) => {
+      return (track.name != seedTrack.name) || (track.artists[0].name != seedTrack.artists[0].name) || (track.album.name != seedTrack.album.name)
+    });
+    this.setState({
+      seedTracks: filteredSeedTracks
+    })
+    console.log(filteredSeedTracks);
+  }
+
+  handleSubmitRec = (e) => {
+    e.preventDefault();
+    let trackIds = this.state.seedTracks.map(track => track.id);
+    console.log(trackIds);
+    axios.post('/queries/recommend',
+    { seedTracks: trackIds},
+    { headers: { Authorization: `Bearer ${Cookies.get("cookie")}`}})
+    .then(res => {
+      console.log(res.data);
+      this.setState({
+        displayRecs: true,
+        recTracks: res.data
+      })
+    })
+    .catch(err => {
+      console.log(err);
+    })
+  }
+
   render() {
     const { data, location } = this.props;
     const { username } = data;
+    let seedTrackDisplay = [];
+    if (this.state.seedTracks !== undefined && this.state.seedTracks.length > 0){
+      seedTrackDisplay = this.state.seedTracks.map((track,i) => {
+          return(<li data-id={i} onClick={(e) => this.removeFromTracks(e,this.state.seedTracks[i])} >{track.name} by {track.artists[0].name} of {track.album.name}</li>)
+      })
+    }
+    let content = (
+      <div className="content">
+      <Search onTrackClick={this.recOnTrackClick}/>
+      <h5>Selected Seed Tracks</h5>
+      {seedTrackDisplay}
+      <Button onClick={(e) => this.handleSubmitRec(e)}>Get Recommendations</Button>
+      </div>
+    )
+    if (this.state.displayRecs){
+      let recDisplay = []
+      if (this.state.recTracks !== undefined && this.state.recTracks.length > 0){
+        recDisplay = this.state.recTracks.map((track,i) => {
+            return(<li data-id={i} >{track.name} by {track.artists[0].name} of {track.album.name}</li>)
+        })
+        content = (
+          <div className="content">
+          <h3>Recommendations</h3>
+          {recDisplay}
+          </div>
+        )
+      }
+    }
+
     return (
       <main>
         <Header name={username} location={location} />
@@ -21,9 +100,7 @@ class Recommendation extends Component {
               <img className="avatar" src="https://i.kym-cdn.com/entries/icons/mobile/000/028/861/cover3.jpg" />
             </MediaQuery>
           </div>
-          <div className="content">
-            <p>Rec stuff</p>
-          </div>
+          {content}
         </div>
       </main>
     )
@@ -31,4 +108,3 @@ class Recommendation extends Component {
 }
 
 export default Recommendation;
-


### PR DESCRIPTION
Profiles:
- Re-implemented some logic in the Profile page to get a user's listeningData if it hasn't been queried for already (i.e. when a newly registered user goes to their profile for the first time)

Recommendations:
- Implemented ability to query for recommendations given up to 5 Seed Tracks
- Still need to implement:
  - Save recommended tracks as a playlist for the user
    - Need to implement '/user/create-playlist' route before we can do this
  - Also allow user to select seedArtists, seedGenres when querying for recommendations
    - Just need to add a dropdown for genres
    - Implementing artists will be a bit more complex, will require changing some logic on the '/search' endpoint as well as the search component to accomplish this