### PR TITLE
create-playlist and various work on /search/ endpoints

### DIFF
--- a/api/routes/queries.js
+++ b/api/routes/queries.js
@@ -50,8 +50,6 @@ EXPECTS:
   HEADERS:
     - 'Authorization': 'Bearer <token>'
 */
-//TODO:
-// - Test this route
 router.get('/user', middlewares.checkToken, function(req, res, next){
   jwt.verify(req.token, jwtSecret, (err, authorizedData) => {
     if(err){
@@ -71,8 +69,6 @@ EXPECTS:
   BODY:
     - N/A
 */
-//TODO:
-// - Test this route
 router.get('/user/:username', function(req, res, next){
   var username = req.params.username;
   queryUtils.getQueriesForUser(res, username);

--- a/api/routes/search.js
+++ b/api/routes/search.js
@@ -37,8 +37,6 @@ EXPECTS:
   BODY:
     - N/A
 */
-//TODO:
-// - Implement this route
 router.get('/', middlewares.checkToken, (req, res) => {
   //Validate Auth Token
   jwt.verify(req.token, jwtSecret, (err, authorizedData) => {
@@ -60,9 +58,9 @@ router.get('/', middlewares.checkToken, (req, res) => {
       const users = db.collection('users');
       users.find({'username': authorizedData['username']}, {'projection': {'password': 0, 'salt': 0}}).toArray( (err, results) => {
         if(err) {
-          console.log(err.data);
+          console.log(err);
           res.status(500);
-          res.json(err.data);
+          res.json(err);
         }
         user = results[0];
         spotifyData.checkRefresh(user, db, spotifyApi, (err, checkedUser) => {
@@ -140,7 +138,7 @@ EXPECTS:
     - N/A
 */
 //TODO:
-// - Implement this route
+// - Save & Query to DB - NOT DONE
 router.get('/album/:albumId', middlewares.checkToken, (req, res) => {
   jwt.verify(req.token, jwtSecret, (err, authorizedData) => {
     if(err){
@@ -209,7 +207,7 @@ EXPECTS:
     - N/A
 */
 //TODO:
-// - Implement this route
+// - Save & Query to DB - NOT DONE
 router.get('/artist/:artistId', middlewares.checkToken, (req, res) => {
   jwt.verify(req.token, jwtSecret, (err, authorizedData) => {
     if(err){
@@ -278,7 +276,7 @@ EXPECTS:
     - N/A
 */
 //TODO:
-// - Implement this route
+// - Save & Query to DB - NOT DONE
 router.get('/playlist/:playlistId', middlewares.checkToken, (req, res) => {
   jwt.verify(req.token, jwtSecret, (err, authorizedData) => {
     if(err){

--- a/api/routes/search.js
+++ b/api/routes/search.js
@@ -54,32 +54,34 @@ router.get('/', middlewares.checkToken, (req, res) => {
         res.send('No query string given.');
         return;
       }
+      var searchType = "track";
+      if (req.query.searchType) searchType = req.query.searchType;
       //Grab User from DB to get spotify auth
       const users = db.collection('users');
       users.find({'username': authorizedData['username']}, {'projection': {'password': 0, 'salt': 0}}).toArray( (err, results) => {
         if(err) {
-          console.log(err);
-          res.json(err);
+          console.log(err.data);
+          res.status(500);
+          res.json(err.data);
         }
         user = results[0];
         spotifyData.checkRefresh(user, db, spotifyApi, (err, checkedUser) => {
           if(err){
-            console.log(err);
+            console.log(err.data);
             res.status(500);
-            res.json(err);
+            res.json(err.data);
           }
           spotifyAccessToken = checkedUser['spotifyAuthTokens']['access'];
-          //TO-DO: For now, will only return tracks; Will eventually also return artists, albums, playlists
-          axios.get(`https://api.spotify.com/v1/search?q=${searchString}&type=track`,
+          axios.get(`https://api.spotify.com/v1/search?q=${searchString}&type=${searchType}`,
           {headers: { Authorization: `Bearer ${spotifyAccessToken}`}})
           .then(results => {
             console.log(results.data)
             res.json(results.data)
           })
           .catch(err => {
-            console.log(err);
+            console.log(err['response'].data);
             res.status(500);
-            res.json(err);
+            res.json(err['response'].data);
           })
         })
       })
@@ -139,10 +141,50 @@ EXPECTS:
 */
 //TODO:
 // - Implement this route
-router.get('/album/:albumId', function(req, res, next){
-  var albumId = req.params.albumId;
-  res.status(501);
-  res.send('Route Not Implemented');
+router.get('/album/:albumId', middlewares.checkToken, (req, res) => {
+  jwt.verify(req.token, jwtSecret, (err, authorizedData) => {
+    if(err){
+      console.log('ERROR: Could not connect to the protected route');
+      res.status(401);
+      res.send('Error with given token');
+    } else {
+      //Check if query string was given
+      var albumId = req.params.albumId;
+      if (!(albumId)){
+        res.status(400);
+        res.send('No query playlist given.');
+        return;
+      }
+      //Grab User from DB to get spotify auth
+      const users = db.collection('users');
+      users.find({'username': authorizedData['username']}, {'projection': {'password': 0, 'salt': 0}}).toArray( (err, results) => {
+        if(err) {
+          console.log(err);
+          res.json(err);
+        }
+        user = results[0];
+        spotifyData.checkRefresh(user, db, spotifyApi, (err, checkedUser) => {
+          if(err){
+            console.log(err);
+            res.status(500);
+            res.json(err);
+          }
+          spotifyAccessToken = checkedUser['spotifyAuthTokens']['access'];
+          axios.get(`https://api.spotify.com/v1/albums/${albumId}/tracks`,
+          {headers: { Authorization: `Bearer ${spotifyAccessToken}`}})
+          .then(results => {
+            //console.log(results.data)
+            res.json(results.data)
+          })
+          .catch(err => {
+            console.log(err['response'].data);
+            res.status(500);
+            res.json(err['response'].data);
+          })
+        })
+      })
+    }
+  })
 });
 
 /* GET search/artist - Get a list of artists in an app's cache
@@ -168,10 +210,50 @@ EXPECTS:
 */
 //TODO:
 // - Implement this route
-router.get('/artist/:artistId', function(req, res, next){
-  var artistId = req.params.artistId;
-  res.status(501);
-  res.send('Route Not Implemented');
+router.get('/artist/:artistId', middlewares.checkToken, (req, res) => {
+  jwt.verify(req.token, jwtSecret, (err, authorizedData) => {
+    if(err){
+      console.log('ERROR: Could not connect to the protected route');
+      res.status(401);
+      res.send('Error with given token');
+    } else {
+      //Check if query string was given
+      var artistId = req.params.artistId;
+      if (!(artistId)){
+        res.status(400);
+        res.send('No query artist given.');
+        return;
+      }
+      //Grab User from DB to get spotify auth
+      const users = db.collection('users');
+      users.find({'username': authorizedData['username']}, {'projection': {'password': 0, 'salt': 0}}).toArray( (err, results) => {
+        if(err) {
+          console.log(err);
+          res.json(err);
+        }
+        user = results[0];
+        spotifyData.checkRefresh(user, db, spotifyApi, (err, checkedUser) => {
+          if(err){
+            console.log(err);
+            res.status(500);
+            res.json(err);
+          }
+          spotifyAccessToken = checkedUser['spotifyAuthTokens']['access'];
+          axios.get(`https://api.spotify.com/v1/artists/${artistId}/top-tracks?country=US`,
+          {headers: { Authorization: `Bearer ${spotifyAccessToken}`}})
+          .then(results => {
+            //console.log(results.data)
+            res.json(results.data)
+          })
+          .catch(err => {
+            console.log(err['response'].data);
+            res.status(500);
+            res.json(err['response'].data);
+          })
+        })
+      })
+    }
+  })
 });
 
 /* GET search/playlist - Get a list of playlists in an app's cache
@@ -197,10 +279,50 @@ EXPECTS:
 */
 //TODO:
 // - Implement this route
-router.get('/playlist/:playlistId', function(req, res, next){
-  var playlistId = req.params.playlistId;
-  res.status(501);
-  res.send('Route Not Implemented');
+router.get('/playlist/:playlistId', middlewares.checkToken, (req, res) => {
+  jwt.verify(req.token, jwtSecret, (err, authorizedData) => {
+    if(err){
+      console.log('ERROR: Could not connect to the protected route');
+      res.status(401);
+      res.send('Error with given token');
+    } else {
+      //Check if query string was given
+      var playlistId = req.params.playlistId;
+      if (!(playlistId)){
+        res.status(400);
+        res.send('No query playlist given.');
+        return;
+      }
+      //Grab User from DB to get spotify auth
+      const users = db.collection('users');
+      users.find({'username': authorizedData['username']}, {'projection': {'password': 0, 'salt': 0}}).toArray( (err, results) => {
+        if(err) {
+          console.log(err);
+          res.json(err);
+        }
+        user = results[0];
+        spotifyData.checkRefresh(user, db, spotifyApi, (err, checkedUser) => {
+          if(err){
+            console.log(err);
+            res.status(500);
+            res.json(err);
+          }
+          spotifyAccessToken = checkedUser['spotifyAuthTokens']['access'];
+          axios.get(`https://api.spotify.com/v1/playlists/${playlistId}/tracks`,
+          {headers: { Authorization: `Bearer ${spotifyAccessToken}`}})
+          .then(results => {
+            //console.log(results.data)
+            res.json(results.data)
+          })
+          .catch(err => {
+            console.log(err);
+            res.status(500);
+            res.json(err);
+          })
+        })
+      })
+    }
+  })
 });
 
 module.exports = router;

--- a/api/routes/user.js
+++ b/api/routes/user.js
@@ -309,6 +309,9 @@ router.get('/listening-data', middlewares.checkToken, (req, res) => {
 EXPECTS:
   HEADERS:
     - 'Authorization': 'Bearer <token>'
+    BODY:
+    - 'playlistName': Desired name of newly created playlist
+    - 'playlistTrackUris': Array of Spotify Track URI's for tracks to be added to playlist
 */
 router.post('/create-playlist', middlewares.checkToken, (req, res) => {
   jwt.verify(req.token, jwtSecret, (err, authorizedData) => {

--- a/api/routes/user.js
+++ b/api/routes/user.js
@@ -304,4 +304,76 @@ router.get('/listening-data', middlewares.checkToken, (req, res) => {
   });
 });
 
+
+/* POST user/create-playlist - To be used in conjunction with recommendations if wants to save recommendations as a playlist
+EXPECTS:
+  HEADERS:
+    - 'Authorization': 'Bearer <token>'
+*/
+router.post('/create-playlist', middlewares.checkToken, (req, res) => {
+  jwt.verify(req.token, jwtSecret, (err, authorizedData) => {
+    if(err){
+      //If error send Forbidden (403)
+      console.log('ERROR: Could not connect to the protected route');
+      res.sendStatus(403);
+    } else {
+      const users = db.collection('users');
+      users.find({'username': authorizedData['username']}, {'projection': {'password': 0, 'salt': 0}}).toArray( (err, results) => {
+        if(err) {
+          console.log(err);
+          res.json(err);
+        }
+        user = results[0];
+        spotifyData.checkRefresh(user, db, spotifyApi, (err, checkedUser) => {
+          if(err){
+            console.log(err);
+            res.status(500);
+            res.json(err);
+          }
+          spotifyAccessToken = checkedUser['spotifyAuthTokens']['access'];
+          axios.get('https://api.spotify.com/v1/me/',
+          {headers: { Authorization: `Bearer ${spotifyAccessToken}`}})
+          .then(results => {
+            console.log(results['data']);
+            const userId = results['data']['id'];
+            axios.post(`https://api.spotify.com/v1/users/${userId}/playlists`,
+            {name: req.body.playlistName, description: "Made using Spotification!"},
+            {headers: { Authorization: `Bearer ${spotifyAccessToken}`, 'Content-Type': 'application/json'}})
+            .then(results => {
+              let playlistId = results['data']['id'];
+              axios.post(`https://api.spotify.com/v1/playlists/${playlistId}/tracks`,
+              {uris: req.body.playlistTrackUris},
+              {headers: { Authorization: `Bearer ${spotifyAccessToken}`, 'Content-Type': 'application/json'}})
+              .then(results => {
+                res.json({playlistMade: true});
+              })
+              .catch(err => {
+                if(err) {
+                  console.log(err);
+                  res.status(500);
+                  res.json(err);
+                }
+              })
+            })
+            .catch(err => {
+              if(err) {
+                console.log(err);
+                res.status(500);
+                res.json(err);
+              }
+            })
+          })
+          .catch(err => {
+            if(err) {
+              console.log(err);
+              res.status(500);
+              res.json(err);
+            }
+          })
+        })
+      });
+    }
+  });
+});
+
 module.exports = router;

--- a/api/utils/spotifyData.js
+++ b/api/utils/spotifyData.js
@@ -160,7 +160,7 @@ const getSimilairity= (data1, data2, next) => {
   let sqrtd2 = Math.sqrt(data2Vals.reduce(squareReducer));
   let denom = sqrtd1*sqrtd2;
   let num = 0;
-  for (int i = 0; i < data1Vals.length; i++){
+  for (let i = 0; i < data1Vals.length; i++){
     num += data1Vals[i]*data2Vals[i];
   }
   return num/denom;

--- a/api/utils/spotifyData.js
+++ b/api/utils/spotifyData.js
@@ -150,4 +150,20 @@ const getAvgFeats = (user, db, songs, next) => {
   })
 }
 
+const getSimilairity= (data1, data2, next) => {
+  delete data1.duration_ms;
+  delete data2.duration_ms;
+  let data1Vals = Object.values(data1);
+  let data2Vals = Object.values(data2);
+  let squareReducer = (accumulator, currentValue) => accumulator + Math.pow(currentValue,2);
+  let sqrtd1 = Math.sqrt(data1Vals.reduce(squareReducer));
+  let sqrtd2 = Math.sqrt(data2Vals.reduce(squareReducer));
+  let denom = sqrtd1*sqrtd2;
+  let num = 0;
+  for (int i = 0; i < data1Vals.length; i++){
+    num += data1Vals[i]*data2Vals[i];
+  }
+  return num/denom;
+}
+
 module.exports = {checkRefresh, getAvgFeats};


### PR DESCRIPTION
- Implemented /user/create-playlist
  - Given playlist name + tracks to include in playlist, allows us to create a playlist for the user
  - To be used by Recommendations page if a user wants to save recommendations as a playlist

- Implemented /search "searchType" query param
  - Allows user to specify what type of entities they want returned on the search call 
   - This includes track, artist, album, playlist
   - If user wants to specify multiple types, must be comma separated
     - Ex: "/search?search=mo%20bamba&searchType=artist,playlist"
  - If searchType query param is not supplied, entities returned defaults to only tracks

- Implemented /search/artist/:id, /search/playlist/:id, /search/album/:id
  - Allows user to get tracks associated with the artist/playlist/album queried for
