### PR TITLE
Baby Got Backend

### DIFF
--- a/api/routes/queries.js
+++ b/api/routes/queries.js
@@ -207,7 +207,6 @@ router.post('/visual', middlewares.checkToken, (req, res) => {
             axios.get(`https://api.spotify.com/v1/tracks?ids=${trackIds.join(',')}`,
             {headers: { Authorization: `Bearer ${spotifyAccessToken}`}})
             .then(results => {
-              //console.log(results['data'])
               req.body['tracks'] = results['data']['tracks'];
               spotifyData.getAvgFeats(checkedUser, db, results['data']['tracks'], (err, data) => {
                 if(err){

--- a/api/routes/queries.js
+++ b/api/routes/queries.js
@@ -126,7 +126,7 @@ router.post('/recommend', middlewares.checkToken, (req, res) => {
             {headers: { Authorization: `Bearer ${spotifyAccessToken}`}})
             .then(results => {
               songs = queryUtils.songParser(results);
-              queryUtils.insertIntoCache('Recommendation', authorizedData['username'], req.body, songs);
+              queryUtils.insertIntoCache('Recommendation', user, req.body, songs);
               res.json(songs);
             })
             .catch(err => {

--- a/api/routes/user.js
+++ b/api/routes/user.js
@@ -189,7 +189,7 @@ router.get('/username/:username', middlewares.checkToken, (req, res) => {
     } else {
       //If token is successfully verified, we can send the autorized data
       const users = db.collection('users');
-      users.find({'username': username}, {'projection': {'password': 0, 'salt': 0, 'spotifyAuth': 0, 'spotifyAuthTokens': 0, 'spotifyAuthUrl': 0}}).toArray( (err, results) => {
+      users.find({'username': username}, {'projection': {'password': 0, 'salt': 0, 'spotifyAuthTokens': 0, 'spotifyAuthUrl': 0}}).toArray( (err, results) => {
         if(err) {
           console.log(err);
           res.status(500);
@@ -201,32 +201,37 @@ router.get('/username/:username', middlewares.checkToken, (req, res) => {
           res.send("Given user does not exist");
         }
         var givenUser = results[0]
-        users.find({'username': authorizedData['username']}, {'projection': {'password': 0, 'salt': 0}}).toArray( (err, results) => {
-          if(err) {
-            console.log(err);
-            res.status(500);
-            res.json(err);
-          }
-          if ( results.length == 0  || !(results) ) {
-            console.log('ERROR: User could not be found');
-            res.status(404);
-            res.send("Given user does not exist");
-          }
-          var loggedInUser = results[0];
-          spotifyData.getSimilairity(givenUser.listeningData.avgFeatures, loggedInUser.listeningData.avgFeatures, (data) => {
-            var similarity = null;
-            //console.log(data);
-            if (data !== -1) similarity = data;
-            givenUser.similarity = data;
-            res.json(givenUser);
-            return;
-          })
-          //console.log(results)
-          //res.json(results);
-        });
-        //res.json(results);
+        if (givenUser.spotifyAuth && givenUser.listeningData){
+          users.find({'username': authorizedData['username']}, {'projection': {'password': 0, 'salt': 0}}).toArray( (err, results) => {
+            if(err) {
+              console.log(err);
+              res.status(500);
+              res.json(err);
+            }
+            if ( results.length == 0  || !(results) ) {
+              console.log('ERROR: User could not be found');
+              res.status(404);
+              res.send("Given user does not exist");
+            }
+            var loggedInUser = results[0];
+            let givenUserFeatures = (givenUser.listeningData ? givenUser.listeningData.avgFeatures : null )
+            let loggedInUserFeatures = (loggedInUser.listeningData ? loggedInUser.listeningData.avgFeatures : null )
+            spotifyData.getSimilairity(givenUserFeatures, loggedInUserFeatures, (data) => {
+              var similarity = null;
+              //console.log(data);
+              if (data !== -1) similarity = data;
+              givenUser.similarity = data;
+              res.json(givenUser);
+              return;
+            })
+            //console.log(results)
+            //res.json(results);
+          });
+        }
+        else{
+          res.json(givenUser);
+        }
       });
-      //res.json({ authorizedData });
     }
   });
 });
@@ -302,28 +307,57 @@ router.post('/spotifyauth', middlewares.checkToken, (req, res) => {
           'refresh': data.body['refresh_token'],
           'expires': timeTokenExpires
         }
-        console.log(authorizedData['username'])
-        const users = db.collection('users');
-        users.updateOne({'username': authorizedData['username']},
-        {$set : {'spotifyAuthTokens': spotifyAuthTokens, 'spotifyAuth': true} },
-        {}, (err, results) => {
-          if(err) {
-            console.log(err);
-            res.status(500);
-            res.json(err);
-          }
-          spotifyApi.setAccessToken(data.body['access_token']);
-          spotifyApi.setRefreshToken(data.body['refresh_token']);
-          users.find({'username': authorizedData['username']}, {'projection': {'password': 0}}).toArray( (err, results) => {
+        axios.get(`https://api.spotify.com/v1/me`,
+        {headers: { Authorization: `Bearer ${data.body['access_token']}`}})
+        .then(results => {
+          console.log(results)
+          let images = results.data.images;
+          const users = db.collection('users');
+          users.updateOne({'username': authorizedData['username']},
+          {$set : {'spotifyAuthTokens': spotifyAuthTokens, 'spotifyAuth': true, 'images': images} },
+          {}, (err, results) => {
             if(err) {
               console.log(err);
               res.status(500);
               res.json(err);
             }
-            console.log(results)
-            res.json(results);
+            spotifyApi.setAccessToken(data.body['access_token']);
+            spotifyApi.setRefreshToken(data.body['refresh_token']);
+            users.find({'username': authorizedData['username']}, {'projection': {'password': 0, 'salt': 0, 'spotifyAuthTokens': 0}}).toArray( (err, results) => {
+              if(err) {
+                console.log(err);
+                res.status(500);
+                res.json(err);
+              }
+              console.log(results)
+              res.json(results);
+            })
           })
-        });
+        })
+        .catch(err => {
+          console.log(err['response'].data);
+          const users = db.collection('users');
+          users.updateOne({'username': authorizedData['username']},
+          {$set : {'spotifyAuthTokens': spotifyAuthTokens, 'spotifyAuth': true} },
+          {}, (err, results) => {
+            if(err) {
+              console.log(err);
+              res.status(500);
+              res.json(err);
+            }
+            spotifyApi.setAccessToken(data.body['access_token']);
+            spotifyApi.setRefreshToken(data.body['refresh_token']);
+            users.find({'username': authorizedData['username']}, {'projection': {'password': 0, 'salt': 0, 'spotifyAuthTokens': 0}}).toArray( (err, results) => {
+              if(err) {
+                console.log(err);
+                res.status(500);
+                res.json(err);
+              }
+              console.log(results)
+              res.json(results);
+            })
+          })
+        })
       })
       .catch( (err) => {
         console.log(err);

--- a/api/utils/queryUtils.js
+++ b/api/utils/queryUtils.js
@@ -191,12 +191,14 @@ const songParser = (results) => {
     song['album'] = {
       name: song['album']['name'],
       id: song['album']['id'],
+      images: song['album']['images']
     }
     artists = []
     for (let artist of song['artists']) {
       artists.push({
         name: artist['name'],
         id: artist['id'],
+        images: artist['images']
       })
     }
     song['artists'] = artists;

--- a/api/utils/queryUtils.js
+++ b/api/utils/queryUtils.js
@@ -73,6 +73,7 @@ const getQueriesForUser = (res, username) => {
  */
 const insertIntoCache = (queryType, user, reqBody, resObj) => {
   const queryCache = db.collection('queries');
+
    if (queryType === 'Recommendation'){
      if (reqBody.seedTracks){
        axios.get(`https://api.spotify.com/v1/tracks?ids=${reqBody.seedTracks}`,
@@ -152,7 +153,7 @@ const insertSongFeatsIntoCache = (ids, results) => {
   // solution will be to hit the cache and add back the results when done
   for (let i = 0; i < ids.length; i++){
     songFeats.insertOne({
-      'song_id': ids[i], 
+      'song_id': ids[i],
       'audioFeats': results[i]
     });
   }
@@ -164,6 +165,7 @@ const insertSongFeatsIntoCache = (ids, results) => {
  */
 const songSearchByIds = (ids, callback) => {
   const songFeats = db.collection('song_feats');
+  //songFeats.drop()
   var id_arr = ids.map(x => {return {'song_id': x}});
   console.log(id_arr)
   songFeats.find({
@@ -176,6 +178,7 @@ const songSearchByIds = (ids, callback) => {
       var used_ids = results.map(x => x['song_id']);
       var new_ids = ids.filter(x => !used_ids.includes(x));
       var final_results = results.map(x => {return x['audioFeats']})
+      console.log(final_results)
       callback({'ids': new_ids, 'results': final_results});
     }
   });
@@ -217,5 +220,5 @@ const songParser = (results) => {
   return songs;
 }
 
-module.exports = {getAllQueries, getQueriesForUser, insertIntoCache, 
+module.exports = {getAllQueries, getQueriesForUser, insertIntoCache,
   songParser, insertSongFeatsIntoCache, songSearchByIds};

--- a/api/utils/queryUtils.js
+++ b/api/utils/queryUtils.js
@@ -73,7 +73,7 @@ const getQueriesForUser = (res, username) => {
  */
 const insertIntoCache = (queryType, user, reqBody, resObj) => {
   const queryCache = db.collection('queries');
-
+  //queryCache.drop()
    if (queryType === 'Recommendation'){
      if (reqBody.seedTracks){
        axios.get(`https://api.spotify.com/v1/tracks?ids=${reqBody.seedTracks}`,
@@ -191,6 +191,7 @@ const songSearchByIds = (ids, callback) => {
 const songParser = (results) => {
   songs = [];
   for (let song of results.data.tracks) {
+    print(song)
     song['album'] = {
       name: song['album']['name'],
       id: song['album']['id'],

--- a/api/utils/queryUtils.js
+++ b/api/utils/queryUtils.js
@@ -114,7 +114,7 @@ const insertIntoCache = (queryType, user, reqBody, resObj) => {
        })
      }
      else if (reqBody.seedArtists){
-       axios.get(`https://api.spotify.com/v1/artists?ids=${seedArtists}`,
+       axios.get(`https://api.spotify.com/v1/artists?ids=${reqBody.seedArtists}`,
        {headers: { Authorization: `Bearer ${spotifyAccessToken}`}})
        .then(results => {
          reqBody['artists'] = results.data.artists;
@@ -191,7 +191,6 @@ const songSearchByIds = (ids, callback) => {
 const songParser = (results) => {
   songs = [];
   for (let song of results.data.tracks) {
-    print(song)
     song['album'] = {
       name: song['album']['name'],
       id: song['album']['id'],

--- a/api/utils/spotifyData.js
+++ b/api/utils/spotifyData.js
@@ -82,6 +82,7 @@ const getAvgFeats = (user, db, songs, next) => {
     song['album'] = {
       name: song['album']['name'],
       id: song['album']['id'],
+      images: song['album']['images']
     }
     artists = []
     //console.log(song)
@@ -89,6 +90,7 @@ const getAvgFeats = (user, db, songs, next) => {
       artists.push({
         name: artist['name'],
         id: artist['id'],
+        images: artist['images']
       })
       genreArtists.push(artist['id']);
     }

--- a/api/utils/spotifyData.js
+++ b/api/utils/spotifyData.js
@@ -83,6 +83,7 @@ const getAvgFeats = (user, db, songs, next) => {
       id: song['album']['id'],
     }
     artists = []
+    //console.log(song)
     for (let artist of song['artists']){
       artists.push({
         name: artist['name'],
@@ -174,16 +175,26 @@ const getSimilairity = (data1, data2, next) => {
   data2.loudness /= -60;
   data1.tempo /= 200;
   data2.tempo /= 200;
-  data1.valence *= 2;
+  /*data1.valence *= 2;
   data2.valence *= 2;
   data1.energy *= 2;
   data2.energy *= 2;
   data1.mode *= 2;
   data2.mode *= 2;
   data1.danceability *= 2;
-  data2.danceability *= 2;
-  let data1Vals = Object.values(data1);
-  let data2Vals = Object.values(data2);
+  data2.danceability *= 2;*/
+  let dataKeys = Object.keys(data1);
+  let data1Vals = []//Object.values(data1);
+  let data2Vals = []//Object.values(data2);
+  for (let key of dataKeys){
+    console.log(key)
+    data1Vals.push(data1[key]);
+    data2Vals.push(data2[key]);
+  }
+  //console.log(data1Vals.length)
+  //console.log(data2Vals.length)
+  //console.log(data1Vals)
+  //console.log(data2Vals)
   let squareReducer = (accumulator, currentValue) => accumulator + Math.pow(currentValue,2);
   let sqrtd1 = Math.sqrt(data1Vals.reduce(squareReducer));
   let sqrtd2 = Math.sqrt(data2Vals.reduce(squareReducer));
@@ -192,6 +203,9 @@ const getSimilairity = (data1, data2, next) => {
   for (let i = 0; i < data1Vals.length; i++){
     num += data1Vals[i]*data2Vals[i];
   }
+  //console.log(num)
+  //console.log(denom)
+  //console.log(num/denom)
   console.log(100 - ((1 - num/denom) * 750))
   next(100 - ((1 - num/denom) * 750));
   return;

--- a/client/src/pages/Recommendation.Js
+++ b/client/src/pages/Recommendation.Js
@@ -256,7 +256,6 @@ class Recommendation extends Component {
                 </TabPanel>
               </Tabs>
             </div>
-
           </div>
         </div>
       </main>


### PR DESCRIPTION
@ilumii As requested, tracks in queries should have images as pictured:
![Screen Shot 2019-05-01 at 9 43 39 PM](https://user-images.githubusercontent.com/9355416/57053172-55920480-6c5a-11e9-80fb-a0603aae71bf.png)
If queries have any tracks to be displayed, the images of the tracks will be listed under the tracks albums.
Note: this will only show up for newly created queries, not the ones that you currently. I suggest you drop the old queries by uncommenting this line in queryUtils:
![Screen Shot 2019-05-01 at 9 40 29 PM](https://user-images.githubusercontent.com/9355416/57053250-cd602f00-6c5a-11e9-9933-c8fba0a84fcf.png)
Once you make a new query, all previous queries will be deleted and the new query will be the only query in the list Remember to recomment once you dropped all the queries.

@AceroM You can call 'user/playlists' to get all of a user's playlists
Also GET /user/ will check if a user has an avatar or not, and if they don't, we get it from spotify as so and will be saved under the user object as "images", as so:
![Screen Shot 2019-05-01 at 9 57 32 PM](https://user-images.githubusercontent.com/9355416/57053450-25e3fc00-6c5c-11e9-9a46-cfa5bd302b0e.png)



Other things done:
- Fixed bug that caused popularity not being calculated for @stellaama 
- Getting similarity score is implemented, might want to change it. 

