### PR TITLE
Remove listening-data call from login

### DIFF
--- a/client/src/pages/LoginAndRegister.js
+++ b/client/src/pages/LoginAndRegister.js
@@ -36,15 +36,14 @@ class Register extends Component {
         .post("/user/login", { username, password })
         .then(res => {
           Cookies.set("cookie", res.data.token);
-          axios.get('/user/listening-data', { headers: {'Authorization' : 'Bearer ' + Cookies.get('cookie')} })
-            .then(resTwo => {
-              this.setState({
-                LnR: false,
-                spotifyAuthUrl: res.data.user.spotifyAuthUrl,
-                spotifyAuth:res.data.user.spotifyAuth,
-                notice: ""
-              });
-            })
+          console.log(res.data)
+          console.log('here')
+          this.setState({
+            LnR: false,
+            spotifyAuthUrl: res.data.user.spotifyAuthUrl,
+            spotifyAuth:res.data.user.spotifyAuth,
+            notice: ""
+          });
         })
         .catch(err => {
           console.log(err);

--- a/client/src/pages/LoginAndRegister.js
+++ b/client/src/pages/LoginAndRegister.js
@@ -36,8 +36,6 @@ class Register extends Component {
         .post("/user/login", { username, password })
         .then(res => {
           Cookies.set("cookie", res.data.token);
-          console.log(res.data)
-          console.log('here')
           this.setState({
             LnR: false,
             spotifyAuthUrl: res.data.user.spotifyAuthUrl,

--- a/client/src/pages/ProtectedRoute.js
+++ b/client/src/pages/ProtectedRoute.js
@@ -14,12 +14,25 @@ function ProtectedRoute({ component: Component, path }) {
     const fetchData = async () => {
       try {
         const result = await axios.get('/user/', { headers: {'Authorization' : 'Bearer ' + Cookies.get('cookie')} });
-
         if (result.status === 200) {
-          setData(result.data);
-          setAuth(true)
+          if (!(result.data[0].listeningData)){
+            try {
+              const result = await axios.get('/user/listening-data', { headers: {'Authorization' : 'Bearer ' + Cookies.get('cookie')} });
+              if (result.status === 200) {
+                setData(result.data);
+                setAuth(true)
+              }
+              setLoad(true);
+            } catch (err) {
+              setLoad(true);
+              console.error(err);
+            }
+          }
+          else{
+            setData(result.data);
+            setAuth(true)
+          }
         }
-
         setLoad(true);
       } catch (err) {
         setLoad(true);


### PR DESCRIPTION
GET user/listening-data/ call was disrupting the auth workflow in login page:
- If you registered, didn't auth with spotify, exited the page, re-entered, and tried to login again, the listening-data call would crash the api as it didn't ensure that user was authorized with spotify.

I removed it and moved it to protected route, as user can only get to this point after being authorized. 