### PR TITLE
Polishing Profile

### DIFF
--- a/client/src/components/HorizontalBarGraph.js
+++ b/client/src/components/HorizontalBarGraph.js
@@ -1,27 +1,18 @@
 import React from 'react'
 import { HorizontalBar } from 'react-chartjs-2';
 
-export default function HorizontalBarGraph({ labels, barData1, label1, barData2, label2 }) {
+export default function HorizontalBarGraph({ title, barData, label }) {
   const data = {
-    labels: labels,
+    labels: barData.map(m => m[0]),
     datasets: [
       {
-        label: label1,
-        backgroundColor: 'rgba(38, 166, 91, 0.3)',
-        borderColor: 'rgba(38, 166, 91, 1)',
+        label,
+        backgroundColor: 'rgba(255,99,132,0.2)',
+        borderColor: 'rgba(255,99,132,1)',
         borderWidth: 1,
-        hoverBackgroundColor: 'rgba(38, 166, 91,0.4)',
-        hoverBorderColor: 'rgba(38, 166, 91, 1)',
-        data: barData1
-      },
-      {
-        label: label2,
-        backgroundColor: 'rgba(245, 230, 83,0.3)',
-        borderColor: 'rgba(245, 230, 83, 1)',
-        borderWidth: 1,
-        hoverBackgroundColor: 'rgba(245, 230, 83, 0.4)',
-        hoverBorderColor: 'rgba(245, 230, 83, 1)',
-        data: barData2
+        hoverBackgroundColor: 'rgba(255,99,132,0.4)',
+        hoverBorderColor: 'rgba(255,99,132,1)',
+        data: barData.map(m => m[1])
       }
     ]
   }

--- a/client/src/components/HorizontalBarGraph.js
+++ b/client/src/components/HorizontalBarGraph.js
@@ -1,18 +1,27 @@
 import React from 'react'
 import { HorizontalBar } from 'react-chartjs-2';
 
-export default function HorizontalBarGraph({ title, barData, label }) {
+export default function HorizontalBarGraph({ labels, barData1, label1, barData2, label2 }) {
   const data = {
-    labels: barData.map(m => m[0]),
+    labels: labels,
     datasets: [
       {
-        label,
-        backgroundColor: 'rgba(255,99,132,0.2)',
-        borderColor: 'rgba(255,99,132,1)',
+        label: label1,
+        backgroundColor: 'rgba(38, 166, 91, 0.3)',
+        borderColor: 'rgba(38, 166, 91, 1)',
         borderWidth: 1,
-        hoverBackgroundColor: 'rgba(255,99,132,0.4)',
-        hoverBorderColor: 'rgba(255,99,132,1)',
-        data: barData.map(m => m[1])
+        hoverBackgroundColor: 'rgba(38, 166, 91,0.4)',
+        hoverBorderColor: 'rgba(38, 166, 91, 1)',
+        data: barData1
+      },
+      {
+        label: label2,
+        backgroundColor: 'rgba(245, 230, 83,0.3)',
+        borderColor: 'rgba(245, 230, 83, 1)',
+        borderWidth: 1,
+        hoverBackgroundColor: 'rgba(245, 230, 83, 0.4)',
+        hoverBorderColor: 'rgba(245, 230, 83, 1)',
+        data: barData2
       }
     ]
   }

--- a/client/src/components/ProfileBarGraph.js
+++ b/client/src/components/ProfileBarGraph.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import { HorizontalBar } from 'react-chartjs-2';
+
+export default function HorizontalBarGraph({ title, barData, label }) {
+  const data = {
+    labels: barData.map(m => m[0]),
+    datasets: [
+      {
+        label,
+        backgroundColor: 'rgba(255,99,132,0.2)',
+        borderColor: 'rgba(255,99,132,1)',
+        borderWidth: 1,
+        hoverBackgroundColor: 'rgba(255,99,132,0.4)',
+        hoverBorderColor: 'rgba(255,99,132,1)',
+        data: barData.map(m => m[1])
+      }
+    ]
+  }
+  return (
+    <HorizontalBar data={data} />
+  )
+}

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -70,16 +70,22 @@ class Profile extends Component {
 
   render() {
     const { profileData, err } = this.state;
-    const { listeningData } = profileData;
+    const { listeningData, images } = profileData;
     const { data, location, profileName } = this.props;
     const { username } = data;
 
     let topSongs, sortedGenres, barData, similarity;
     if (listeningData) {
       similarity = profileData.similarity;
-      topSongs = Object.entries(listeningData.songs).map(item => [item[1].artists[0].name, item[1].name])
+      topSongs = Object.entries(listeningData.songs).map(item => `${item[1].name} by ${item[1].artists[0].name}`)
       sortedGenres = listeningData.sortedGenres;
       barData = sortedGenres.map(g => [g.genre, g.count]).slice(0, 7);
+    }
+
+    let avatar = "https://i.kym-cdn.com/entries/icons/mobile/000/028/861/cover3.jpg";
+    if (images && images[0] && images[0]['url']){
+      console.log(avatar)
+      avatar = images[0]['url'];
     }
 
     return (
@@ -88,10 +94,10 @@ class Profile extends Component {
         <div className="home-container">
           <div className="sidebar">
             <MediaQuery query="(min-width: 768px)">
-              <img className="avatar" src="https://i.kym-cdn.com/entries/icons/mobile/000/028/861/cover3.jpg" />
+              <img className="avatar" src={avatar} />
             </MediaQuery>
             <h1>{profileName}</h1>
-            <div className="similarity-container">
+            { username !== profileName && (<div className="similarity-container">
               <h2>Similarity Score</h2>
               { similarity && (
                 <CircularProgressbar
@@ -118,7 +124,7 @@ class Profile extends Component {
                   }}
                 />
               )}
-            </div>
+            </div>)}
           </div>
           <div className="content">
             <h1>{!!err.length && err }</h1>

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -8,7 +8,7 @@ import '../styles/Profile.css';
 
 import { Bar } from 'react-chartjs-2';
 import DarkCard from '../components/DarkCard'
-import HorizontalBarGraph from '../components/HorizontalBarGraph'
+import ProfileBarGraph from '../components/ProfileBarGraph'
 import CircularProgressbar from 'react-circular-progressbar';
 import Chart from '../components/Chart';
 import axios from "axios";
@@ -135,7 +135,7 @@ class Profile extends Component {
               </DarkCard>
               <DarkCard>
                 <h1> Favorite Genres</h1>
-                { listeningData && <HorizontalBarGraph label={"Count"} barData={barData} />}
+                { listeningData && <ProfileBarGraph label={"Count"} barData={barData} />}
               </DarkCard>
             </div>
           </div>


### PR DESCRIPTION
Reverted HorizontalBarGraph component back so it's working on profile again:
Before Revert:
![Screen Shot 2019-05-06 at 3 41 34 PM](https://user-images.githubusercontent.com/9355416/57251917-fdbc1a80-7018-11e9-9f33-b5ed36214f1c.png)
After Revert:
![Screen Shot 2019-05-06 at 3 44 32 PM](https://user-images.githubusercontent.com/9355416/57251994-27754180-7019-11e9-96d5-36e489941a9f.png)

Changed Similarity Score to only appear if you're looking at someone else's prof
  - Would not make sense to look at similarity with yourself (i.e. always 100)


Changed Avatar to be your Spotify Avatar if it exists
  - If it doesn't it defaults to Tom

User's Own Profile with Avatar:
![Screen Shot 2019-05-06 at 4 02 31 PM](https://user-images.githubusercontent.com/9355416/57252334-de71bd00-7019-11e9-9234-0c8b875c8e51.png)

Another User's Profile without Avatar:
![Screen Shot 2019-05-06 at 4 02 50 PM](https://user-images.githubusercontent.com/9355416/57252349-e29dda80-7019-11e9-98c7-859b34bdc2fb.png)

